### PR TITLE
refactor the proc macro client generator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "near-abi-client",
+    "near-abi-client-impl",
     "near-abi-client-macros",
 ]
 exclude = ["examples/"]

--- a/examples/delegator-generation/Cargo.toml
+++ b/examples/delegator-generation/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
+
 near-sdk = { version = "4.1.0-pre.0", features = ["abi"] }
-near-abi-client = { path = "../../near-abi-client" }
 workspaces = "0.3.1"
 
 [dev-dependencies]
@@ -14,4 +14,5 @@ tokio = { version = "1.14", features = ["full"] }
 
 [build-dependencies]
 anyhow = "1.0"
+
 near-abi-client = { path = "../../near-abi-client" }

--- a/examples/delegator-macro/Cargo.toml
+++ b/examples/delegator-macro/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
-name = "delegator-generation"
+name = "delegator-macro"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0"
-near-sdk = { version = "4.1.0-pre.0", features = ["abi"] }
-near-abi-client-macros = { path = "../../near-abi-client-macros" }
-serde_json = "1.0"
 serde = "1.0"
 tokio = { version = "1.14", features = ["full"] }
+anyhow = "1.0"
+serde_json = "1.0"
+
+near-sdk = { version = "4.1.0-pre.0", features = ["abi"] }
 workspaces = "0.3.1"
+near-abi-client = { path = "../../near-abi-client" }

--- a/examples/delegator-macro/src/lib.rs
+++ b/examples/delegator-macro/src/lib.rs
@@ -1,7 +1,8 @@
-use near_abi_client_macros::near_abi_client;
 use workspaces::network::DevAccountDeployer;
 
-near_abi_client! { type AbiClient for "src/adder.json" }
+mod adder {
+    near_abi_client::generate!(Client for "src/adder.json");
+}
 
 pub async fn run(a: u32, b: u32, c: u32, d: u32) -> anyhow::Result<(u32, u32)> {
     let worker = workspaces::sandbox().await?;
@@ -9,7 +10,7 @@ pub async fn run(a: u32, b: u32, c: u32, d: u32) -> anyhow::Result<(u32, u32)> {
         .dev_deploy(include_bytes!("../res/adder.wasm"))
         .await?;
 
-    let contract = AbiClient { contract };
+    let contract = adder::Client { contract };
     let res = contract
         .add(&worker, vec![a.into(), b.into()], vec![c.into(), d.into()])
         .await?;

--- a/examples/delegator-macro/tests/mod.rs
+++ b/examples/delegator-macro/tests/mod.rs
@@ -1,4 +1,4 @@
-use delegator_generation::run;
+use delegator_macro::run;
 
 #[tokio::test]
 async fn test_client() -> anyhow::Result<()> {

--- a/near-abi-client-impl/Cargo.toml
+++ b/near-abi-client-impl/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "near-abi-client-impl"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/near/near-abi-client-rs"
+
+[dependencies]
+quote = "1.0"
+anyhow = "1.0"
+serde_json = "1.0"
+proc-macro2 = "1.0"
+schemafy_lib = { git = "https://github.com/near/schemafy", rev = "4fc8de1ef94f66db1f45889feebb9cf6b931dd94" }
+
+near-sdk = { version = "4.1.0-pre.0", features = ["abi"] }

--- a/near-abi-client-impl/src/lib.rs
+++ b/near-abi-client-impl/src/lib.rs
@@ -1,8 +1,9 @@
 use std::path::{Path, PathBuf};
 
-use near_sdk::__private::{AbiRoot, AbiType};
 use quote::{format_ident, quote};
 use schemafy_lib::{Expander, Generator, Schema};
+
+use near_sdk::__private::{AbiRoot, AbiType};
 
 pub fn generate_abi_client(
     near_abi: AbiRoot,

--- a/near-abi-client-macros/Cargo.toml
+++ b/near-abi-client-macros/Cargo.toml
@@ -10,8 +10,6 @@ repository = "https://github.com/near/near-abi-client-rs"
 proc-macro = true
 
 [dependencies]
-convert_case = "0.5"
-near-abi-client = { path = "../near-abi-client" }
-proc-macro2 = "1.0"
 syn = "1.0"
-quote = "1.0"
+
+near-abi-client-impl = { path = "../near-abi-client-impl" }

--- a/near-abi-client-macros/src/lib.rs
+++ b/near-abi-client-macros/src/lib.rs
@@ -1,8 +1,9 @@
-use near_abi_client::__private::{generate_abi_client, read_abi};
 use std::path::PathBuf;
 
+use near_abi_client_impl::{generate_abi_client, read_abi};
+
 #[proc_macro]
-pub fn near_abi_client(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn generate(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let abi_def = syn::parse_macro_input!(tokens as AbiDef);
     let near_abi = read_abi(PathBuf::from(&abi_def.path.value()));
 
@@ -18,7 +19,6 @@ struct AbiDef {
 
 impl syn::parse::Parse for AbiDef {
     fn parse(input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
-        input.parse::<syn::Token![type]>()?;
         let name = input.parse::<syn::Ident>()?;
         input.parse::<syn::Token![for]>()?;
         let path = input.parse()?;

--- a/near-abi-client/Cargo.toml
+++ b/near-abi-client/Cargo.toml
@@ -7,15 +7,14 @@ readme = "README.md"
 repository = "https://github.com/near/near-abi-client-rs"
 
 [dependencies]
-anyhow = "1.0"
-convert_case = "0.5"
-near-sdk = { version = "4.1.0-pre.0", features = ["abi"] }
-prettyplease = "0.1"
-proc-macro2 = "1.0"
-schemafy_lib = { git = "https://github.com/near/schemafy", rev = "4fc8de1ef94f66db1f45889feebb9cf6b931dd94" }
-serde_json = "1.0"
 syn = "1.0"
 quote = "1.0"
+anyhow = "1.0"
+convert_case = "0.5"
+prettyplease = "0.1"
+
+near-abi-client-impl = { path = "../near-abi-client-impl" }
+near-abi-client-macros = { path = "../near-abi-client-macros" }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/near-abi-client/src/lib.rs
+++ b/near-abi-client/src/lib.rs
@@ -1,16 +1,14 @@
-use __private::{generate_abi_client, read_abi};
-use anyhow::{anyhow, Result};
-use convert_case::{Case, Casing};
-use quote::format_ident;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 use std::{env, fs};
 
-// Private functions shared between macro & generation APIs, not stable to be used.
-#[doc(hidden)]
-#[path = "private/mod.rs"]
-pub mod __private;
+use anyhow::{anyhow, Result};
+use convert_case::{Case, Casing};
+use quote::format_ident;
+
+use near_abi_client_impl::{generate_abi_client, read_abi};
+pub use near_abi_client_macros::generate;
 
 /// Configuration options for ABI code generation.
 #[derive(Default)]

--- a/near-abi-client/tests/mod.rs
+++ b/near-abi-client/tests/mod.rs
@@ -1,7 +1,9 @@
-use near_abi_client::Generator;
-use quote::quote;
 use std::fs;
+
+use quote::quote;
 use tempdir::TempDir;
+
+use near_abi_client::Generator;
 
 #[test]
 fn test_generate_abi() -> anyhow::Result<()> {


### PR DESCRIPTION
Before

```rust
use near_abi_client_macros::near_abi_client;

near_abi_client! { type AbiClient for "src/adder.json" }
```

After

```rust
near_abi_client::generate!(Client for "src/adder.json");
```