### PR TITLE
chore: release

### DIFF
--- a/examples/delegator-generation/Cargo.toml
+++ b/examples/delegator-generation/Cargo.toml
@@ -13,4 +13,4 @@ tokio = { version = "1.14", features = ["full"] }
 
 [build-dependencies]
 anyhow = "1.0"
-near-abi-client = { path = "../../near-abi-client", version = "0.1.0" }
+near-abi-client = { path = "../../near-abi-client", version = "0.1.1" }

--- a/examples/delegator-macro/Cargo.toml
+++ b/examples/delegator-macro/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 near-workspaces = "0.10.0"
-near-abi-client = { path = "../../near-abi-client", version = "0.1.0" }
+near-abi-client = { path = "../../near-abi-client", version = "0.1.1" }
 
 [dev-dependencies]
 tokio = { version = "1.14", features = ["full"] }

--- a/near-abi-client-impl/CHANGELOG.md
+++ b/near-abi-client-impl/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/near/near-abi-client-rs/compare/near-abi-client-impl-v0.1.0...near-abi-client-impl-v0.1.1) - 2024-01-25
+
+### Fixed
+- bump dependency versions ([#14](https://github.com/near/near-abi-client-rs/pull/14))

--- a/near-abi-client-impl/Cargo.toml
+++ b/near-abi-client-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-abi-client-impl"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/near-abi-client-macros/CHANGELOG.md
+++ b/near-abi-client-macros/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/near/near-abi-client-rs/compare/near-abi-client-macros-v0.1.0...near-abi-client-macros-v0.1.1) - 2024-01-25
+
+### Other
+- updated the following local packages: near-abi-client-impl

--- a/near-abi-client-macros/Cargo.toml
+++ b/near-abi-client-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-abi-client-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -15,4 +15,4 @@ proc-macro = true
 [dependencies]
 syn = "1.0"
 
-near-abi-client-impl = { path = "../near-abi-client-impl", version = "0.1.0" }
+near-abi-client-impl = { path = "../near-abi-client-impl", version = "0.1.1" }

--- a/near-abi-client/CHANGELOG.md
+++ b/near-abi-client/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/near/near-abi-client-rs/compare/near-abi-client-v0.1.0...near-abi-client-v0.1.1) - 2024-01-25
+
+### Fixed
+- bump dependency versions ([#14](https://github.com/near/near-abi-client-rs/pull/14))

--- a/near-abi-client/Cargo.toml
+++ b/near-abi-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-abi-client"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.56.0"
 license = "MIT OR Apache-2.0"
@@ -17,8 +17,8 @@ anyhow = "1.0"
 convert_case = "0.5"
 prettyplease = "0.1"
 
-near-abi-client-impl = { path = "../near-abi-client-impl", version = "0.1.0" }
-near-abi-client-macros = { path = "../near-abi-client-macros", version = "0.1.0" }
+near-abi-client-impl = { path = "../near-abi-client-impl", version = "0.1.1" }
+near-abi-client-macros = { path = "../near-abi-client-macros", version = "0.1.1" }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## 🤖 New release
* `near-abi-client`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `near-abi-client-impl`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `near-abi-client-macros`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-abi-client`
<blockquote>

## [0.1.1](https://github.com/near/near-abi-client-rs/compare/near-abi-client-v0.1.0...near-abi-client-v0.1.1) - 2024-01-25

### Fixed
- bump dependency versions ([#14](https://github.com/near/near-abi-client-rs/pull/14))
</blockquote>

## `near-abi-client-impl`
<blockquote>

## [0.1.1](https://github.com/near/near-abi-client-rs/compare/near-abi-client-impl-v0.1.0...near-abi-client-impl-v0.1.1) - 2024-01-25

### Fixed
- bump dependency versions ([#14](https://github.com/near/near-abi-client-rs/pull/14))
</blockquote>

## `near-abi-client-macros`
<blockquote>

## [0.1.1](https://github.com/near/near-abi-client-rs/compare/near-abi-client-macros-v0.1.0...near-abi-client-macros-v0.1.1) - 2024-01-25

### Other
- updated the following local packages: near-abi-client-impl
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).