### PR TITLE
chore: upgrade to Rust edition 2024

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,6 @@
+[advisories]
+ignore = [
+    # time has a DoS vulnerability (stack exhaustion), fixed in 0.3.47+ which requires Rust 1.88
+    # TODO(nearcore#15026): Remove this when rust-toolchain.toml is updated to >= 1.88
+    "RUSTSEC-2026-0009",
+]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,4 +72,4 @@ jobs:
         run: cargo install cargo-audit
 
       - name: Run Audit Tool
-        run: cargo audit --ignore RUSTSEC-2021-0145 --ignore RUSTSEC-2023-0033
+        run: cargo audit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [workspace]
-resolver = "3"
 members = [
     "near-abi-client",
     "near-abi-client-impl",
     "near-abi-client-macros",
     "examples/*",
 ]
+resolver = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "near-abi-client",
     "near-abi-client-impl",

--- a/examples/delegator-generation/Cargo.toml
+++ b/examples/delegator-generation/Cargo.toml
@@ -2,7 +2,7 @@
 publish = false
 name = "delegator-generation"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0"

--- a/examples/delegator-generation/Cargo.toml
+++ b/examples/delegator-generation/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0"
-near-workspaces = "0.10.0"
+near-workspaces = "0.22.0"
 
 [dev-dependencies]
 tokio = { version = "1.14", features = ["full"] }

--- a/examples/delegator-macro/Cargo.toml
+++ b/examples/delegator-macro/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0"
-near-workspaces = "0.10.0"
+near-workspaces = "0.22.0"
 near-abi-client = { path = "../../near-abi-client", version = "0.1.1" }
 
 [dev-dependencies]

--- a/examples/delegator-macro/Cargo.toml
+++ b/examples/delegator-macro/Cargo.toml
@@ -2,7 +2,7 @@
 publish = false
 name = "delegator-macro"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0"

--- a/near-abi-client-impl/Cargo.toml
+++ b/near-abi-client-impl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "near-abi-client-impl"
 version = "0.1.1"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/near/near-abi-client-rs"

--- a/near-abi-client-macros/Cargo.toml
+++ b/near-abi-client-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "near-abi-client-macros"
 version = "0.1.1"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/near/near-abi-client-rs"

--- a/near-abi-client/Cargo.toml
+++ b/near-abi-client/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "near-abi-client"
 version = "0.1.1"
-edition = "2021"
-rust-version = "1.56.0"
+edition = "2024"
+rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/near/near-abi-client-rs"

--- a/near-abi-client/src/lib.rs
+++ b/near-abi-client/src/lib.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::{env, fs};
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use convert_case::{Case, Casing};
 use quote::format_ident;
 


### PR DESCRIPTION
Updates the crate to Rust edition 2024 with resolver v3.