### PR TITLE
fix: update near-workspaces to resolve audit vulnerabilities

### DIFF
--- a/examples/delegator-generation/Cargo.toml
+++ b/examples/delegator-generation/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-near-workspaces = "0.10.0"
+near-workspaces = "0.22"
 
 [dev-dependencies]
 tokio = { version = "1.14", features = ["full"] }

--- a/examples/delegator-macro/Cargo.toml
+++ b/examples/delegator-macro/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-near-workspaces = "0.10.0"
+near-workspaces = "0.22"
 near-abi-client = { path = "../../near-abi-client", version = "0.1.1" }
 
 [dev-dependencies]


### PR DESCRIPTION
Updates `near-workspaces` from 0.10.0 to 0.22 in examples to resolve cargo-audit security warnings.

The old version pulled in outdated transitive dependencies:
- `proc-macro-error` (unmaintained)
- `ed25519-dalek` <2 (CVE)
- `curve25519-dalek` <4.1.3 (timing vulnerability)

All resolved by updating to near-workspaces 0.22.