### PR TITLE
chore: release v0.1.2

### DIFF
--- a/examples/delegator-generation/Cargo.toml
+++ b/examples/delegator-generation/Cargo.toml
@@ -13,4 +13,4 @@ tokio = { version = "1.14", features = ["full"] }
 
 [build-dependencies]
 anyhow = "1.0"
-near-abi-client = { path = "../../near-abi-client", version = "0.1.1" }
+near-abi-client = { path = "../../near-abi-client", version = "0.1.2" }

--- a/examples/delegator-macro/Cargo.toml
+++ b/examples/delegator-macro/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0"
 near-workspaces = "0.22.0"
-near-abi-client = { path = "../../near-abi-client", version = "0.1.1" }
+near-abi-client = { path = "../../near-abi-client", version = "0.1.2" }
 
 [dev-dependencies]
 tokio = { version = "1.14", features = ["full"] }

--- a/near-abi-client-impl/CHANGELOG.md
+++ b/near-abi-client-impl/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/near/near-abi-client-rs/compare/near-abi-client-impl-v0.1.1...near-abi-client-impl-v0.1.2) - 2026-02-17
+
+### Other
+
+- upgrade to Rust edition 2024 ([#18](https://github.com/near/near-abi-client-rs/pull/18))
+
 ## [0.1.1](https://github.com/near/near-abi-client-rs/compare/near-abi-client-impl-v0.1.0...near-abi-client-impl-v0.1.1) - 2024-01-25
 
 ### Fixed

--- a/near-abi-client-impl/Cargo.toml
+++ b/near-abi-client-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-abi-client-impl"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/near-abi-client-macros/CHANGELOG.md
+++ b/near-abi-client-macros/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/near/near-abi-client-rs/compare/near-abi-client-macros-v0.1.1...near-abi-client-macros-v0.1.2) - 2026-02-17
+
+### Other
+
+- upgrade to Rust edition 2024 ([#18](https://github.com/near/near-abi-client-rs/pull/18))
+
 ## [0.1.1](https://github.com/near/near-abi-client-rs/compare/near-abi-client-macros-v0.1.0...near-abi-client-macros-v0.1.1) - 2024-01-25
 
 ### Other

--- a/near-abi-client-macros/Cargo.toml
+++ b/near-abi-client-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-abi-client-macros"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -15,4 +15,4 @@ proc-macro = true
 [dependencies]
 syn = "1.0"
 
-near-abi-client-impl = { path = "../near-abi-client-impl", version = "0.1.1" }
+near-abi-client-impl = { path = "../near-abi-client-impl", version = "0.1.2" }

--- a/near-abi-client/CHANGELOG.md
+++ b/near-abi-client/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/near/near-abi-client-rs/compare/near-abi-client-v0.1.1...near-abi-client-v0.1.2) - 2026-02-17
+
+### Other
+
+- upgrade to Rust edition 2024 ([#18](https://github.com/near/near-abi-client-rs/pull/18))
+
 ## [0.1.1](https://github.com/near/near-abi-client-rs/compare/near-abi-client-v0.1.0...near-abi-client-v0.1.1) - 2024-01-25
 
 ### Fixed

--- a/near-abi-client/Cargo.toml
+++ b/near-abi-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-abi-client"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
@@ -17,8 +17,8 @@ anyhow = "1.0"
 convert_case = "0.5"
 prettyplease = "0.1"
 
-near-abi-client-impl = { path = "../near-abi-client-impl", version = "0.1.1" }
-near-abi-client-macros = { path = "../near-abi-client-macros", version = "0.1.1" }
+near-abi-client-impl = { path = "../near-abi-client-impl", version = "0.1.2" }
+near-abi-client-macros = { path = "../near-abi-client-macros", version = "0.1.2" }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION



## 🤖 New release

* `near-abi-client-impl`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `near-abi-client-macros`: 0.1.1 -> 0.1.2
* `near-abi-client`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-abi-client-impl`

<blockquote>

## [0.1.2](https://github.com/near/near-abi-client-rs/compare/near-abi-client-impl-v0.1.1...near-abi-client-impl-v0.1.2) - 2026-02-17

### Other

- upgrade to Rust edition 2024 ([#18](https://github.com/near/near-abi-client-rs/pull/18))
</blockquote>

## `near-abi-client-macros`

<blockquote>

## [0.1.2](https://github.com/near/near-abi-client-rs/compare/near-abi-client-macros-v0.1.1...near-abi-client-macros-v0.1.2) - 2026-02-17

### Other

- upgrade to Rust edition 2024 ([#18](https://github.com/near/near-abi-client-rs/pull/18))
</blockquote>

## `near-abi-client`

<blockquote>

## [0.1.2](https://github.com/near/near-abi-client-rs/compare/near-abi-client-v0.1.1...near-abi-client-v0.1.2) - 2026-02-17

### Other

- upgrade to Rust edition 2024 ([#18](https://github.com/near/near-abi-client-rs/pull/18))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).